### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/195/621/421195621.geojson
+++ b/data/421/195/621/421195621.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"KY",
     "wof:created":1459009854,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4c6fe486f433f89d2878a95cdbe523d",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":421195621,
-    "wof:lastmodified":1566591083,
+    "wof:lastmodified":1582319707,
     "wof:name":"Brinkleys",
     "wof:parent_id":85681183,
     "wof:placetype":"locality",

--- a/data/857/935/29/85793529.geojson
+++ b/data/857/935/29/85793529.geojson
@@ -96,6 +96,10 @@
         "wd:id":"Q572451"
     },
     "wof:country":"KY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f419e9e43ab976c0ebed089990310f07",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591080,
+    "wof:lastmodified":1582319707,
     "wof:name":"Dog City",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.