### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/173/021/421173021.geojson
+++ b/data/421/173/021/421173021.geojson
@@ -41,6 +41,9 @@
     "name:pol_x_preferred":[
         "West Bay"
     ],
+    "name:rus_x_preferred":[
+        "\u0423\u044d\u0441\u0442-\u0411\u0435\u0439"
+    ],
     "name:spa_x_preferred":[
         "West Bay"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421173021,
-    "wof:lastmodified":1566591083,
+    "wof:lastmodified":1690938380,
     "wof:name":"West Bay",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/179/089/421179089.geojson
+++ b/data/421/179/089/421179089.geojson
@@ -38,6 +38,9 @@
     "name:pol_x_preferred":[
         "Bodden Town"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u043e\u0434\u0434\u0435\u043d-\u0422\u0430\u0443\u043d"
+    ],
     "name:spa_x_preferred":[
         "Bodden Town"
     ],
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":421179089,
-    "wof:lastmodified":1566591083,
+    "wof:lastmodified":1690938380,
     "wof:name":"Bodden Town",
     "wof:parent_id":85681183,
     "wof:placetype":"locality",

--- a/data/857/935/29/85793529.geojson
+++ b/data/857/935/29/85793529.geojson
@@ -39,8 +39,14 @@
     "name:fra_x_preferred":[
         "Les Crocs malins"
     ],
+    "name:hin_x_preferred":[
+        "\u0921\u0949\u0917 \u0938\u093f\u091f\u0940"
+    ],
     "name:hun_x_preferred":[
         "Kutyavil\u00e1g"
+    ],
+    "name:ita_x_preferred":[
+        "Dog City"
     ],
     "name:nld_x_preferred":[
         "Dog City"
@@ -116,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582319707,
+    "wof:lastmodified":1690938380,
     "wof:name":"Dog City",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/434/947/890434947.geojson
+++ b/data/890/434/947/890434947.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "North Side"
+    ],
     "name:eng_x_preferred":[
         "North Side"
     ],
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":890434947,
-    "wof:lastmodified":1636496049,
+    "wof:lastmodified":1690938380,
     "wof:name":"North Side",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/949/890434949.geojson
+++ b/data/890/434/949/890434949.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u062c\u0648\u0631\u062c \u062a\u0627\u0648\u0646"
     ],
+    "name:arg_x_preferred":[
+        "George Town"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0631\u062c \u062a\u0627\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "George Town"
     ],
@@ -92,6 +98,9 @@
     "name:fra_x_preferred":[
         "George Town"
     ],
+    "name:gle_x_preferred":[
+        "George Town"
+    ],
     "name:glg_x_preferred":[
         "George Town"
     ],
@@ -113,10 +122,16 @@
     "name:hun_x_preferred":[
         "George Town"
     ],
+    "name:hye_x_preferred":[
+        "\u054b\u0578\u0580\u057b\u0569\u0561\u0578\u0582\u0576"
+    ],
     "name:ido_x_preferred":[
         "Georgetown"
     ],
     "name:ind_x_preferred":[
+        "George Town"
+    ],
+    "name:isl_x_preferred":[
         "George Town"
     ],
     "name:ita_x_preferred":[
@@ -169,6 +184,9 @@
     ],
     "name:oci_x_preferred":[
         "George Town"
+    ],
+    "name:oss_x_preferred":[
+        "\u0414\u0436\u043e\u0440\u0434\u0436\u0442\u0430\u0443\u043d"
     ],
     "name:pol_x_preferred":[
         "Georgetown"
@@ -230,6 +248,9 @@
     "name:war_x_preferred":[
         "Georgetown"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e54\u6cbb\u6566"
+    ],
     "name:yor_x_preferred":[
         "George Town"
     ],
@@ -273,7 +294,7 @@
         }
     ],
     "wof:id":890434949,
-    "wof:lastmodified":1566591083,
+    "wof:lastmodified":1690938380,
     "wof:name":"George Town",
     "wof:parent_id":85681183,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.